### PR TITLE
Apply patches

### DIFF
--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/primitive-types/Cargo.toml
+++ b/primitive-types/Cargo.toml
@@ -10,8 +10,9 @@ rust-version = "1.60.0"
 
 [dependencies]
 fixed-hash = { version = "0.8", path = "../fixed-hash", default-features = false }
-uint = { version = "0.9.5", path = "../uint", default-features = false }
+uint = { version = "0.9.5", default-features = false }
 impl-serde = { version = "0.4.0", path = "impls/serde", default-features = false, optional = true }
+impl-borsh = { version = "0.1.0", path = "impls/borsh", default-features = false, optional = true }
 impl-codec = { version = "0.6.0", path = "impls/codec", default-features = false, optional = true }
 impl-num-traits = { version = "0.1.0", path = "impls/num-traits", default-features = false, optional = true }
 impl-rlp = { version = "0.3", path = "impls/rlp", default-features = false, optional = true }
@@ -30,6 +31,7 @@ rlp = ["impl-rlp"]
 arbitrary = ["fixed-hash/arbitrary", "uint/arbitrary"]
 fp-conversion = ["std"]
 num-traits = ["impl-num-traits"]
+borsh = ["impl-borsh"]
 
 [[test]]
 name = "scale_info"

--- a/primitive-types/impls/borsh/CHANGELOG.md
+++ b/primitive-types/impls/borsh/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+The format is based on [Keep a Changelog].
+
+[Keep a Changelog]: http://keepachangelog.com/en/1.0.0/

--- a/primitive-types/impls/borsh/Cargo.toml
+++ b/primitive-types/impls/borsh/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "impl-borsh"
+version = "0.1.0"
+authors = ["Steven Sloboda <steven@eclipse.builders>"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/paritytech/parity-common"
+description = "Borsh serialization support for uint and fixed hash."
+edition = "2021"
+rust-version = "1.56.1"
+
+[features]
+default = ["std",]
+std = ["borsh/std"]
+
+[dependencies]
+borsh = { version = "0.9.3", default-features = false, features = ["std"] }

--- a/primitive-types/impls/borsh/src/lib.rs
+++ b/primitive-types/impls/borsh/src/lib.rs
@@ -1,0 +1,57 @@
+#![allow(warnings)]
+// Copyright 2022 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Serde serialization support for uint and fixed hash.
+
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[doc(hidden)]
+pub use borsh;
+
+/// Add Borsh serialization support to an integer created by `construct_uint!`.
+#[macro_export]
+macro_rules! impl_uint_borsh {
+    ($name: ident, $len: expr) => {
+        impl $crate::borsh::BorshSerialize for $name {
+            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+                self.0.serialize(writer)
+            }
+        }
+
+        impl $crate::borsh::BorshDeserialize for $name {
+            fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+                <[u64; $len]>::deserialize(buf).map(|bytes| Self(bytes))
+            }
+        }
+    };
+}
+
+/// Add Borsh serialization support to a fixed-sized hash type created by `construct_fixed_hash!`.
+#[macro_export]
+macro_rules! impl_fixed_hash_borsh {
+    ($name: ident, $len: expr) => {
+        impl $crate::borsh::BorshSerialize for $name {
+            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+                self.0.serialize(writer)
+            }
+        }
+
+        impl $crate::borsh::BorshDeserialize for $name {
+            fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+                <[u8; $len]>::deserialize(buf).map(|bytes| Self(bytes))
+            }
+        }
+    };
+}

--- a/primitive-types/impls/codec/src/lib.rs
+++ b/primitive-types/impls/codec/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/primitive-types/impls/num-traits/Cargo.toml
+++ b/primitive-types/impls/num-traits/Cargo.toml
@@ -11,4 +11,4 @@ rust-version = "1.56.1"
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 integer-sqrt = "0.1"
-uint = { version = "0.9.5", path = "../../../uint", default-features = false }
+uint = { version = "0.9.5", default-features = false }

--- a/primitive-types/impls/num-traits/src/lib.rs
+++ b/primitive-types/impls/num-traits/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/primitive-types/impls/rlp/src/lib.rs
+++ b/primitive-types/impls/rlp/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/primitive-types/impls/serde/Cargo.toml
+++ b/primitive-types/impls/serde/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.101", default-features = false, features = ["alloc"] }
 criterion = "0.3.0"
 serde_derive = "1.0.101"
 serde_json = "1.0.41"
-uint = { version = "0.9.5", path = "../../../uint" }
+uint = "0.9.5"
 
 [[bench]]
 name = "impl_serde"

--- a/primitive-types/impls/serde/src/lib.rs
+++ b/primitive-types/impls/serde/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/primitive-types/src/lib.rs
+++ b/primitive-types/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -137,6 +138,21 @@ mod rlp {
 	impl_fixed_hash_rlp!(H384, 48);
 	impl_fixed_hash_rlp!(H512, 64);
 	impl_fixed_hash_rlp!(H768, 96);
+}
+
+#[cfg(feature = "impl-borsh")]
+mod borsh {
+	use super::*;
+	use impl_borsh::{impl_fixed_hash_borsh, impl_uint_borsh};
+
+	impl_uint_borsh!(U128, 2);
+	impl_uint_borsh!(U256, 4);
+	impl_uint_borsh!(U512, 8);
+
+	impl_fixed_hash_borsh!(H128, 16);
+	impl_fixed_hash_borsh!(H160, 20);
+	impl_fixed_hash_borsh!(H256, 32);
+	impl_fixed_hash_borsh!(H512, 64);
 }
 
 impl_fixed_hash_conversions!(H256, H160);

--- a/rlp-derive/src/lib.rs
+++ b/rlp-derive/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(warnings)]
 // Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or


### PR DESCRIPTION
Generated these using Mattie's patch tool from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/2434 using commit `91c9f4ef4` and running the `vendor.rs` script, and then copying the vendored contents into my fork.

I made one small change, which was to change the PatchDirective to use the upstream parity-common repo, instead of the Eclipse-forked one:
```
    PatchDirective {
        name: "parity-common",
        url: "https://github.com/paritytech/parity-common.git",
        refspec: Rev("c41d51df8a314150c46cbbff31f8140a35dfb02c"),
        patches: &["primitive-types-borsh.patch"],
        crates: &[
            PatchCrateDirective {
                name: "primitive-types",
                version: "0.12.1",
                path: "primitive-types",
            },
            PatchCrateDirective {
                name: "rlp",
                version: "0.5.2",
                path: "rlp",
            },
        ],
    },
```

I chose the fork point to be the commit in which `master` on the Eclipse fork is at - this is so that the existing patch in Mattie's branch applies